### PR TITLE
Fixed errors in ShinyApp template

### DIFF
--- a/ProjectTemplates/ShinyApp/AuthService.cs
+++ b/ProjectTemplates/ShinyApp/AuthService.cs
@@ -8,7 +8,7 @@ namespace ShinyApp;
 // THIS IS NOT MEANT TO BE A COMPLETE SERVICE.  IT IS MEANT ONLY AS A GOOD STARTING POINT
 public interface IAuthService
 {
-    string? AuthenticationToken { get; }
+    string? AuthenticationToken { get; set; }
     Task<bool> Authenticate();
     Task SignOut();    
     Task<bool> TryRefresh();
@@ -18,6 +18,7 @@ public interface IAuthService
 #if usewebauthenticator
 public class WebAuthenticatorAuthService : IAuthService 
 {
+    public string? AuthenticationToken { get; set; }
     public async Task<bool> Authenticate()
     {
         var scheme = "..."; // Apple, Microsoft, Google, Facebook, etc.
@@ -71,6 +72,7 @@ public class WebAuthenticatorAuthService : IAuthService
 #if usemsal
 public class MsalAuthenticationService : IAuthService
 {
+    public string? AuthenticationToken { get; set; }
     static readonly string[] SCOPES = new [] { "User.Read" };
     readonly MsalOptions options;
     readonly IPublicClientApplication pca;

--- a/ProjectTemplates/ShinyApp/Platforms/Android/MainActivity.cs
+++ b/ProjectTemplates/ShinyApp/Platforms/Android/MainActivity.cs
@@ -1,5 +1,10 @@
 ﻿using Android.App;
 using Android.Content.PM;
+#if (usemsal)
+using Android.Content;
+using Android.Runtime;
+using Microsoft.Identity.Client;
+#endif
 
 namespace ShinyApp;
 

--- a/ProjectTemplates/ShinyApp/ShinyApp.csproj
+++ b/ProjectTemplates/ShinyApp/ShinyApp.csproj
@@ -134,6 +134,7 @@
 		<!--#endif-->
 		<!--#if usehttp-->
 		<PackageReference Include="Refit.HttpClientFactory" Version="6.3.2" />
+		<PackageReference Include="Shiny.Net.Http" Version="$(ShinyVersion)" />
 		<!--#endif-->
 	</ItemGroup>
 


### PR DESCRIPTION
- Implementors of IAuthService did not implement  AuthenticationToken
- AuthenticationToken was being assigned, but was get-only
- Missing usings in MainActivity when using MSAL
- Missing Shiny.Net.Http package reference when using http downloads. I'm not sure if this should be with the <!--#if usehttp-->, or if <!--#if usehttptransfers--> should be added.