### PR TITLE
Use overridable styles for UraniumUI

### DIFF
--- a/ProjectTemplates/ShinyApp/App.xaml
+++ b/ProjectTemplates/ShinyApp/App.xaml
@@ -9,13 +9,13 @@
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <!--#if (uraniumui)-->
+                <ResourceDictionary x:Name="appColors" Source="Resources/Styles/Colors.xaml" />
+                <ResourceDictionary x:Name="appStyles" Source="Resources/Styles/Styles.xaml" />
+                <material:StyleResource BasedOn="{x:Reference appStyles}" ColorsOverride="{x:Reference appColors}" />
+                <!--#else-->
                 <ResourceDictionary Source="Resources/Styles/Colors.xaml" />
-                <!--#if (uraniumui)-->
-                <material:ColorResource />
-                <!--#endif-->
                 <ResourceDictionary Source="Resources/Styles/Styles.xaml" />
-                <!--#if (uraniumui)-->
-                <material:StyleResource />
                 <!--#endif-->
                 <ResourceDictionary Source="Resources/Styles/Templates.xaml" />
             </ResourceDictionary.MergedDictionaries>


### PR DESCRIPTION
This PR just applies the [Migration guide to v2.4](https://enisn-projects.io/docs/en/uranium/latest/migration-guides/Migrating-To-2.4)

The styling usage is different in the latest version, I think this usage is much more flexible in the end application. I hope you accept and update the template.

Best regards
